### PR TITLE
Corrected include names "pp.functional" and "pp.behavioral"

### DIFF
--- a/cells/top_gpio_ovtv2/sky130_fd_io__top_gpio_ovtv2.v
+++ b/cells/top_gpio_ovtv2/sky130_fd_io__top_gpio_ovtv2.v
@@ -33,9 +33,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_gpio_ovtv2.pp.functional.v"
+`include "sky130_fd_io__top_gpio_ovtv2.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_gpio_ovtv2.pp.behavioral.v"
+`include "sky130_fd_io__top_gpio_ovtv2.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS

--- a/cells/top_gpiov2/sky130_fd_io__top_gpiov2.v
+++ b/cells/top_gpiov2/sky130_fd_io__top_gpiov2.v
@@ -33,9 +33,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_gpiov2.pp.functional.v"
+`include "sky130_fd_io__top_gpiov2.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_gpiov2.pp.behavioral.v"
+`include "sky130_fd_io__top_gpiov2.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS

--- a/cells/top_ground_hvc_wpad/sky130_fd_io__top_ground_hvc_wpad.v
+++ b/cells/top_ground_hvc_wpad/sky130_fd_io__top_ground_hvc_wpad.v
@@ -33,9 +33,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_ground_hvc_wpad.pp.functional.v"
+`include "sky130_fd_io__top_ground_hvc_wpad.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_ground_hvc_wpad.pp.behavioral.v"
+`include "sky130_fd_io__top_ground_hvc_wpad.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS

--- a/cells/top_ground_lvc_wpad/sky130_fd_io__top_ground_lvc_wpad.v
+++ b/cells/top_ground_lvc_wpad/sky130_fd_io__top_ground_lvc_wpad.v
@@ -33,9 +33,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_ground_lvc_wpad.pp.functional.v"
+`include "sky130_fd_io__top_ground_lvc_wpad.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_ground_lvc_wpad.pp.behavioral.v"
+`include "sky130_fd_io__top_ground_lvc_wpad.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS

--- a/cells/top_power_hvc_wpad/sky130_fd_io__top_power_hvc_wpad.v
+++ b/cells/top_power_hvc_wpad/sky130_fd_io__top_power_hvc_wpad.v
@@ -33,9 +33,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_power_hvc_wpad.pp.functional.v"
+`include "sky130_fd_io__top_power_hvc_wpad.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_power_hvc_wpad.pp.behavioral.v"
+`include "sky130_fd_io__top_power_hvc_wpad.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS

--- a/cells/top_power_hvc_wpadv2/sky130_fd_io__top_power_hvc_wpadv2.v
+++ b/cells/top_power_hvc_wpadv2/sky130_fd_io__top_power_hvc_wpadv2.v
@@ -33,9 +33,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_power_hvc_wpadv2.pp.functional.v"
+`include "sky130_fd_io__top_power_hvc_wpadv2.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_power_hvc_wpadv2.pp.behavioral.v"
+`include "sky130_fd_io__top_power_hvc_wpadv2.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS

--- a/cells/top_power_lvc_wpad/sky130_fd_io__top_power_lvc_wpad.v
+++ b/cells/top_power_lvc_wpad/sky130_fd_io__top_power_lvc_wpad.v
@@ -33,9 +33,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_power_lvc_wpad.pp.functional.v"
+`include "sky130_fd_io__top_power_lvc_wpad.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_power_lvc_wpad.pp.behavioral.v"
+`include "sky130_fd_io__top_power_lvc_wpad.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS

--- a/cells/top_refgen/sky130_fd_io__top_refgen.v
+++ b/cells/top_refgen/sky130_fd_io__top_refgen.v
@@ -38,9 +38,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_refgen.pp.functional.v"
+`include "sky130_fd_io__top_refgen.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_refgen.pp.behavioral.v"
+`include "sky130_fd_io__top_refgen.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS

--- a/cells/top_refgen_new/sky130_fd_io__top_refgen_new.v
+++ b/cells/top_refgen_new/sky130_fd_io__top_refgen_new.v
@@ -36,9 +36,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_refgen_new.pp.functional.v"
+`include "sky130_fd_io__top_refgen_new.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_refgen_new.pp.behavioral.v"
+`include "sky130_fd_io__top_refgen_new.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS

--- a/cells/top_sio/sky130_fd_io__top_sio.v
+++ b/cells/top_sio/sky130_fd_io__top_sio.v
@@ -35,9 +35,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_sio.pp.functional.v"
+`include "sky130_fd_io__top_sio.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_sio.pp.behavioral.v"
+`include "sky130_fd_io__top_sio.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS

--- a/cells/top_sio_macro/sky130_fd_io__top_sio_macro.v
+++ b/cells/top_sio_macro/sky130_fd_io__top_sio_macro.v
@@ -34,9 +34,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_sio_macro.pp.functional.v"
+`include "sky130_fd_io__top_sio_macro.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_sio_macro.pp.behavioral.v"
+`include "sky130_fd_io__top_sio_macro.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS

--- a/cells/top_xres4v2/sky130_fd_io__top_xres4v2.v
+++ b/cells/top_xres4v2/sky130_fd_io__top_xres4v2.v
@@ -33,9 +33,9 @@
 `ifdef USE_POWER_PINS
 
 `ifdef FUNCTIONAL
-`include "sky130_fd_io__top_xres4v2.pp.functional.v"
+`include "sky130_fd_io__top_xres4v2.functional.pp.v"
 `else  // FUNCTIONAL
-`include "sky130_fd_io__top_xres4v2.pp.behavioral.v"
+`include "sky130_fd_io__top_xres4v2.behavioral.pp.v"
 `endif // FUNCTIONAL
 
 `else  // USE_POWER_PINS


### PR DESCRIPTION
Corrected the include names with "pp.functional" and "pp.behavioral" which should be "functional.pp" and "behavioral.pp" to be syntactically correctly (the incorrect use of the term "behavioral" will be addressed separately).