### PR TITLE
Applied PR 1 from google repo, by Anton Blanchard

### DIFF
--- a/cells/top_gpio_ovtv2/sky130_fd_io__top_gpio_ovtv2.functional.pp.v
+++ b/cells/top_gpio_ovtv2/sky130_fd_io__top_gpio_ovtv2.functional.pp.v
@@ -512,12 +512,12 @@ begin
             ->event_error_enable_vddio;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===ERROR=== sky130_fd_io__top_gpio_ovtv2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each \other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power \domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
+                $display(" ===ERROR=== sky130_fd_io__top_gpio_ovtv2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -539,7 +539,7 @@ begin
             else
                 if (msg_count_pad1 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -561,7 +561,7 @@ begin
             else
                 if (msg_count_pad2 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -583,7 +583,7 @@ begin
             else
                 if (msg_count_pad3 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -605,7 +605,7 @@ begin
             else
                 if (msg_count_pad4 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -627,7 +627,7 @@ begin
             else
                 if (msg_count_pad5 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -649,7 +649,7 @@ begin
             else
                 if (msg_count_pad6 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -671,7 +671,7 @@ begin
             else
                 if (msg_count_pad7 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -693,7 +693,7 @@ begin
             else
                 if (msg_count_pad8 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -715,7 +715,7 @@ begin
             else
                 if (msg_count_pad9 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -737,7 +737,7 @@ begin
             else
                 if (msg_count_pad10 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -759,7 +759,7 @@ begin
             else
                 if (msg_count_pad11 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -781,7 +781,7 @@ begin
             else
                 if (msg_count_pad12 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end

--- a/cells/top_gpio_ovtv2/sky130_fd_io__top_gpio_ovtv2.functional.v
+++ b/cells/top_gpio_ovtv2/sky130_fd_io__top_gpio_ovtv2.functional.v
@@ -513,12 +513,12 @@ begin
             ->event_error_enable_vddio;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===ERROR=== sky130_fd_io__top_gpio_ovtv2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each \other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power \domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
+                $display(" ===ERROR=== sky130_fd_io__top_gpio_ovtv2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -540,7 +540,7 @@ begin
             else
                 if (msg_count_pad1 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -562,7 +562,7 @@ begin
             else
                 if (msg_count_pad2 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -584,7 +584,7 @@ begin
             else
                 if (msg_count_pad3 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -606,7 +606,7 @@ begin
             else
                 if (msg_count_pad4 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -628,7 +628,7 @@ begin
             else
                 if (msg_count_pad5 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -650,7 +650,7 @@ begin
             else
                 if (msg_count_pad6 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -672,7 +672,7 @@ begin
             else
                 if (msg_count_pad7 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -694,7 +694,7 @@ begin
             else
                 if (msg_count_pad8 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -716,7 +716,7 @@ begin
             else
                 if (msg_count_pad9 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -738,7 +738,7 @@ begin
             else
                 if (msg_count_pad10 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -760,7 +760,7 @@ begin
             else
                 if (msg_count_pad11 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -782,7 +782,7 @@ begin
             else
                 if (msg_count_pad12 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end

--- a/cells/top_gpio_ovtv2/sky130_fd_io__top_gpio_ovtv2.timing.pp.v
+++ b/cells/top_gpio_ovtv2/sky130_fd_io__top_gpio_ovtv2.timing.pp.v
@@ -636,12 +636,12 @@ begin
             ->event_error_enable_vddio;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===ERROR=== sky130_fd_io__top_gpio_ovtv2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each \other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power \domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
+                $display(" ===ERROR=== sky130_fd_io__top_gpio_ovtv2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -663,7 +663,7 @@ begin
             else
                 if (msg_count_pad1 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -685,7 +685,7 @@ begin
             else
                 if (msg_count_pad2 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -707,7 +707,7 @@ begin
             else
                 if (msg_count_pad3 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -729,7 +729,7 @@ begin
             else
                 if (msg_count_pad4 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -751,7 +751,7 @@ begin
             else
                 if (msg_count_pad5 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -773,7 +773,7 @@ begin
             else
                 if (msg_count_pad6 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -795,7 +795,7 @@ begin
             else
                 if (msg_count_pad7 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -817,7 +817,7 @@ begin
             else
                 if (msg_count_pad8 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -839,7 +839,7 @@ begin
             else
                 if (msg_count_pad9 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -861,7 +861,7 @@ begin
             else
                 if (msg_count_pad10 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -883,7 +883,7 @@ begin
             else
                 if (msg_count_pad11 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -905,7 +905,7 @@ begin
             else
                 if (msg_count_pad12 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end

--- a/cells/top_gpio_ovtv2/sky130_fd_io__top_gpio_ovtv2.timing.v
+++ b/cells/top_gpio_ovtv2/sky130_fd_io__top_gpio_ovtv2.timing.v
@@ -637,12 +637,12 @@ begin
             ->event_error_enable_vddio;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===ERROR=== sky130_fd_io__top_gpio_ovtv2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each \other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power \domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
+                $display(" ===ERROR=== sky130_fd_io__top_gpio_ovtv2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -664,7 +664,7 @@ begin
             else
                 if (msg_count_pad1 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -686,7 +686,7 @@ begin
             else
                 if (msg_count_pad2 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -708,7 +708,7 @@ begin
             else
                 if (msg_count_pad3 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -730,7 +730,7 @@ begin
             else
                 if (msg_count_pad4 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -752,7 +752,7 @@ begin
             else
                 if (msg_count_pad5 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -774,7 +774,7 @@ begin
             else
                 if (msg_count_pad6 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -796,7 +796,7 @@ begin
             else
                 if (msg_count_pad7 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -818,7 +818,7 @@ begin
             else
                 if (msg_count_pad8 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -840,7 +840,7 @@ begin
             else
                 if (msg_count_pad9 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -862,7 +862,7 @@ begin
             else
                 if (msg_count_pad10 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -884,7 +884,7 @@ begin
             else
                 if (msg_count_pad11 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -906,7 +906,7 @@ begin
             else
                 if (msg_count_pad12 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpio_ovtv2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end

--- a/cells/top_gpiov2/sky130_fd_io__top_gpiov2.functional.pp.v
+++ b/cells/top_gpiov2/sky130_fd_io__top_gpiov2.functional.pp.v
@@ -426,12 +426,12 @@ begin
             ->event_error_enable_vddio;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===ERROR=== sky130_fd_io__top_gpiov2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each \other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power \domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
+                $display(" ===ERROR=== sky130_fd_io__top_gpiov2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -453,7 +453,7 @@ begin
             else
                 if (msg_count_pad1 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -475,7 +475,7 @@ begin
             else
                 if (msg_count_pad2 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -497,7 +497,7 @@ begin
             else
                 if (msg_count_pad3 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -519,7 +519,7 @@ begin
             else
                 if (msg_count_pad4 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -541,7 +541,7 @@ begin
             else
                 if (msg_count_pad5 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -563,7 +563,7 @@ begin
             else
                 if (msg_count_pad6 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -585,7 +585,7 @@ begin
             else
                 if (msg_count_pad7 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -607,7 +607,7 @@ begin
             else
                 if (msg_count_pad8 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -629,7 +629,7 @@ begin
             else
                 if (msg_count_pad9 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -651,7 +651,7 @@ begin
             else
                 if (msg_count_pad10 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -673,7 +673,7 @@ begin
             else
                 if (msg_count_pad11 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -695,7 +695,7 @@ begin
             else
                 if (msg_count_pad12 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end

--- a/cells/top_gpiov2/sky130_fd_io__top_gpiov2.functional.v
+++ b/cells/top_gpiov2/sky130_fd_io__top_gpiov2.functional.v
@@ -426,12 +426,12 @@ begin
             ->event_error_enable_vddio;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===ERROR=== sky130_fd_io__top_gpiov2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each \other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power \domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
+                $display(" ===ERROR=== sky130_fd_io__top_gpiov2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -453,7 +453,7 @@ begin
             else
                 if (msg_count_pad1 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -475,7 +475,7 @@ begin
             else
                 if (msg_count_pad2 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -497,7 +497,7 @@ begin
             else
                 if (msg_count_pad3 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -519,7 +519,7 @@ begin
             else
                 if (msg_count_pad4 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -541,7 +541,7 @@ begin
             else
                 if (msg_count_pad5 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -563,7 +563,7 @@ begin
             else
                 if (msg_count_pad6 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -585,7 +585,7 @@ begin
             else
                 if (msg_count_pad7 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -607,7 +607,7 @@ begin
             else
                 if (msg_count_pad8 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -629,7 +629,7 @@ begin
             else
                 if (msg_count_pad9 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -651,7 +651,7 @@ begin
             else
                 if (msg_count_pad10 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -673,7 +673,7 @@ begin
             else
                 if (msg_count_pad11 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -695,7 +695,7 @@ begin
             else
                 if (msg_count_pad12 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end

--- a/cells/top_gpiov2/sky130_fd_io__top_gpiov2.timing.pp.v
+++ b/cells/top_gpiov2/sky130_fd_io__top_gpiov2.timing.pp.v
@@ -520,12 +520,12 @@ begin
             ->event_error_enable_vddio;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===ERROR=== sky130_fd_io__top_gpiov2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each \other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power \domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
+                $display(" ===ERROR=== sky130_fd_io__top_gpiov2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -547,7 +547,7 @@ begin
             else
                 if (msg_count_pad1 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -569,7 +569,7 @@ begin
             else
                 if (msg_count_pad2 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -591,7 +591,7 @@ begin
             else
                 if (msg_count_pad3 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -613,7 +613,7 @@ begin
             else
                 if (msg_count_pad4 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -635,7 +635,7 @@ begin
             else
                 if (msg_count_pad5 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -657,7 +657,7 @@ begin
             else
                 if (msg_count_pad6 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -679,7 +679,7 @@ begin
             else
                 if (msg_count_pad7 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -701,7 +701,7 @@ begin
             else
                 if (msg_count_pad8 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -723,7 +723,7 @@ begin
             else
                 if (msg_count_pad9 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -745,7 +745,7 @@ begin
             else
                 if (msg_count_pad10 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -767,7 +767,7 @@ begin
             else
                 if (msg_count_pad11 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -789,7 +789,7 @@ begin
             else
                 if (msg_count_pad12 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end

--- a/cells/top_gpiov2/sky130_fd_io__top_gpiov2.timing.v
+++ b/cells/top_gpiov2/sky130_fd_io__top_gpiov2.timing.v
@@ -520,12 +520,12 @@ begin
             ->event_error_enable_vddio;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===ERROR=== sky130_fd_io__top_gpiov2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each \other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power \domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
+                $display(" ===ERROR=== sky130_fd_io__top_gpiov2 :  Enable_h (= %b) and ENABLE_VDDIO (= %b) are complement of each other. This is an illegal combination as ENABLE_VDDIO and ENABLE_H are the same input signals IN different power domains %m", ENABLE_H, ENABLE_VDDIO, $stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -547,7 +547,7 @@ begin
             else
                 if (msg_count_pad1 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -569,7 +569,7 @@ begin
             else
                 if (msg_count_pad2 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -591,7 +591,7 @@ begin
             else
                 if (msg_count_pad3 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -613,7 +613,7 @@ begin
             else
                 if (msg_count_pad4 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -635,7 +635,7 @@ begin
             else
                 if (msg_count_pad5 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -657,7 +657,7 @@ begin
             else
                 if (msg_count_pad6 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -679,7 +679,7 @@ begin
             else
                 if (msg_count_pad7 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -701,7 +701,7 @@ begin
             else
                 if (msg_count_pad8 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -723,7 +723,7 @@ begin
             else
                 if (msg_count_pad9 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -745,7 +745,7 @@ begin
             else
                 if (msg_count_pad10 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -767,7 +767,7 @@ begin
             else
                 if (msg_count_pad11 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -789,7 +789,7 @@ begin
             else
                 if (msg_count_pad12 == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_gpiov2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end

--- a/cells/top_xres4v2/sky130_fd_io__top_xres4v2.functional.pp.v
+++ b/cells/top_xres4v2/sky130_fd_io__top_xres4v2.functional.pp.v
@@ -169,12 +169,12 @@ begin
             ->event_errflag_pad_pulse_width;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for PAD input (= %3.2f ns)  is found to be in \the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",pad_pulse_width,min_delay,max_delay,$stime);
+                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for PAD input (= %3.2f ns)  is found to be in the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",pad_pulse_width,min_delay,max_delay,$stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -189,12 +189,12 @@ begin
             ->event_errflag_filt_in_h_pulse_width;
             if (msg_count_filt_in_h <= MAX_WARNING_COUNT)
             begin
-                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for FILT_IN_H input (= %3.2f ns)  is found to be in \the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",filt_in_h_pulse_width,min_delay,max_delay,$stime);
+                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for FILT_IN_H input (= %3.2f ns)  is found to be in the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",filt_in_h_pulse_width,min_delay,max_delay,$stime);
             end
             else
                 if (msg_count_filt_in_h == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end

--- a/cells/top_xres4v2/sky130_fd_io__top_xres4v2.functional.v
+++ b/cells/top_xres4v2/sky130_fd_io__top_xres4v2.functional.v
@@ -168,12 +168,12 @@ begin
             ->event_errflag_pad_pulse_width;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for PAD input (= %3.2f ns)  is found to be in \the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",pad_pulse_width,min_delay,max_delay,$stime);
+                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for PAD input (= %3.2f ns)  is found to be in the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",pad_pulse_width,min_delay,max_delay,$stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -188,12 +188,12 @@ begin
             ->event_errflag_filt_in_h_pulse_width;
             if (msg_count_filt_in_h <= MAX_WARNING_COUNT)
             begin
-                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for FILT_IN_H input (= %3.2f ns)  is found to be in \the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",filt_in_h_pulse_width,min_delay,max_delay,$stime);
+                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for FILT_IN_H input (= %3.2f ns)  is found to be in the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",filt_in_h_pulse_width,min_delay,max_delay,$stime);
             end
             else
                 if (msg_count_filt_in_h == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end

--- a/cells/top_xres4v2/sky130_fd_io__top_xres4v2.timing.pp.v
+++ b/cells/top_xres4v2/sky130_fd_io__top_xres4v2.timing.pp.v
@@ -171,12 +171,12 @@ begin
             ->event_errflag_pad_pulse_width;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for PAD input (= %3.2f ns)  is found to be in \the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",pad_pulse_width,min_delay,max_delay,$stime);
+                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for PAD input (= %3.2f ns)  is found to be in the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",pad_pulse_width,min_delay,max_delay,$stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -191,12 +191,12 @@ begin
             ->event_errflag_filt_in_h_pulse_width;
             if (msg_count_filt_in_h <= MAX_WARNING_COUNT)
             begin
-                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for FILT_IN_H input (= %3.2f ns)  is found to be in \the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",filt_in_h_pulse_width,min_delay,max_delay,$stime);
+                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for FILT_IN_H input (= %3.2f ns)  is found to be in the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",filt_in_h_pulse_width,min_delay,max_delay,$stime);
             end
             else
                 if (msg_count_filt_in_h == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end

--- a/cells/top_xres4v2/sky130_fd_io__top_xres4v2.timing.v
+++ b/cells/top_xres4v2/sky130_fd_io__top_xres4v2.timing.v
@@ -170,12 +170,12 @@ begin
             ->event_errflag_pad_pulse_width;
             if (msg_count_pad <= MAX_WARNING_COUNT)
             begin
-                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for PAD input (= %3.2f ns)  is found to be in \the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",pad_pulse_width,min_delay,max_delay,$stime);
+                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for PAD input (= %3.2f ns)  is found to be in the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",pad_pulse_width,min_delay,max_delay,$stime);
             end
             else
                 if (msg_count_pad == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end
@@ -190,12 +190,12 @@ begin
             ->event_errflag_filt_in_h_pulse_width;
             if (msg_count_filt_in_h <= MAX_WARNING_COUNT)
             begin
-                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for FILT_IN_H input (= %3.2f ns)  is found to be in \the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",filt_in_h_pulse_width,min_delay,max_delay,$stime);
+                $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Width of Input pulse for FILT_IN_H input (= %3.2f ns)  is found to be in the range: %3d ns - %3d ns. In this range, the delay and pulse suppression of the input pulse are PVT dependent. : \%m",filt_in_h_pulse_width,min_delay,max_delay,$stime);
             end
             else
                 if (msg_count_filt_in_h == MAX_WARNING_COUNT+1)
                 begin
-                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the \message count has exceeded 100 %m",$stime);
+                    $display(" ===WARNING=== sky130_fd_io__top_xres4v2 :  Further WARNING messages will be suppressed as the message count has exceeded 100 %m",$stime);
                 end
         end
     end


### PR DESCRIPTION
Remove invalid escape sequences from $display strings.  There are a number of strings that contain backslashes, probably previously escaping a line break. Verilator warns about them, so we may as well fix it.